### PR TITLE
[Request For Comments] Adding material -> attribute indirection to EXT_pbr_attributes

### DIFF
--- a/extensions/2.0/Vendor/EXT_pbr_attributes/README.md
+++ b/extensions/2.0/Vendor/EXT_pbr_attributes/README.md
@@ -23,11 +23,11 @@ Written against the glTF 2.0 spec.
 
 ## Overview
 
-This extension defines the metalness-roughness material model from Physically-Based Rendering (PBR) adding additional material parameters, which reference per vertex attributes. These additional material parameters, complete a full PBR workflow representation per vertex.
+This extension defines the metalness-roughness material model from Physically-Based Rendering (PBR), adding additional material parameters, which reference per vertex attributes. These additional material parameters, complete a full PBR workflow representation per vertex.
 
-This extension allows meshes to have attributes of any name, and allows materials to select those attributes together with a swizzle (ie. rgba, r, a), so that attributes can be packed into a compact form (for example: METALLIC_ROUGHNESS_AMBIENTOCCLUSION as a single 3-component vector attribute).
+This extension allows meshes to have attributes of any name, and allows materials to select channels from those attributes using a swizzle parameter (ie. "rgba", "r", "a"), so attributes can be packed into a compact form (for example, artist can pack METALLIC_ROUGHNESS_AMBIENTOCCLUSION as a single 3-component vector attribute).
 
-This material <-> attribute indirection allows DCC applications to save multiple materials for a single mesh into glTF, and allows real-time engines to switch / blend between them at run-time. It also allows DCC applications to use glTF as a storage format, used for saving and loading artist defined shading configurations, minimizing data loss and/or shading configuration change / conversion over the save and load cycle(s).
+Such material <-> attribute indirection allows DCC applications to save multiple materials for a single mesh into a glTF file, and allows real-time engines to switch / blend between them at run-time. It also allows DCC applications to use glTF as a storage format, used for saving and loading artist defined shading configurations, while minimizing data loss and/or shading configuration change / conversion over the save and load cycle(s).
 
 ### Example
 ![\[Comparison\]](Figures/vertex_metal_rough_comparison.png)
@@ -59,14 +59,14 @@ Left: per-vertex albedo only. Right: per-vertex albedo attributes extended with 
             "extensions" : {
                 "EXT_pbr_attributes" : {
                     "baseColorAttribSpace" : "sRGB",
-					"baseColorAttrib" : "COLOR_0",
-					"baseColorSwizzle" : "rgb",
-					"roughnessAttribSpace" : "linear",
-					"roughnessAttrib" : "ROUGHNESS_METALLIC",
-					"roughnessSwizzle" : "r",
-					"metallicAttribSpace" : "linear",
-					"metallicAttrib" : "ROUGHNESS_METALLIC",
-					"metallicSwizzle" : "b",
+                    "baseColorAttrib" : "COLOR_0",
+                    "baseColorSwizzle" : "rgb",
+                    "roughnessAttribSpace" : "linear",
+                    "roughnessAttrib" : "ROUGHNESS_METALLIC",
+                    "roughnessSwizzle" : "r",
+                    "metallicAttribSpace" : "linear",
+                    "metallicAttrib" : "ROUGHNESS_METALLIC",
+                    "metallicSwizzle" : "b",
                 }
             }
         }
@@ -99,13 +99,13 @@ This extension adds on additional `enum` to the `materials` section.
 
 [Schema for color space selection](Schema/glTF.EXT_pbr_attributes.schema.json)
 
-This enum provides information about the color space interpretation of the  vertex attributes used. If not present, `"linear"` is assumed. If color space is sRGB, the implementation is required to convert the color to linear space in order to correctly interpolate via the fixed function pipeline.
+This enum provides information about the color space interpretation of the  vertex attributes used. If not present, `"linear"` is assumed. If color space is "sRGB", the implementation is required to convert the color to linear space in order to correctly interpolate via the fixed function pipeline.
 
 If one or more of the attributes are referenced by the material, they must be multiplied with the respective factor, for example, "roughnessAttrib" float value has to be multiplied with "roughnessFactor" of the pbrMetallicRoughness material.
 
 If a relevant texture (for example, metallicRoughnessTexture) is defined in the material, an implementation must multiply the texture values with both attribute value and constant factor.
 
-Swizzle is defined as one or more of letters in the standard 4 component vector "rgba". To simplify the implementations, each letter can appear only once in the swizzle string, so for example, "rrgg" swizzle is not allowed.
+Swizzle is defined as one or more of letters in the standard 4 component vector "rgba". To simplify extension implementations, each letter can appear only once in the swizzle string, so for example, "rrgg" swizzle is not allowed.
 
 ### Attributes
 
@@ -114,7 +114,7 @@ This extension also allows any accessor type and component type for each attribu
 
 ## Best Practices
 
-The primary motivation of this extension is to allow PBR materials to be represented primarily by vertex attributes.
+The primary motivation of this extension is to allow PBR materials to be represented by additional material parameters.
 For this use case, it is recommended to set both "metallicFactor" and "roughnessFactor" to 1.0. Both factors can be then interpreted and used as a global "knob" for artistic control.
 Loaders should pay attention to floating point precision such that 1.0 is exactly represented.
 

--- a/extensions/2.0/Vendor/EXT_pbr_attributes/README.md
+++ b/extensions/2.0/Vendor/EXT_pbr_attributes/README.md
@@ -23,9 +23,9 @@ Written against the glTF 2.0 spec.
 
 ## Overview
 
-This extension defines the metalness-roughness material model from Physically-Based Rendering (PBR), adding additional material parameters, which reference per vertex attributes. These additional material parameters, allow for a full PBR workflow representation, per vertex.
+This extension improves the definition of metalness-roughness material model from Physically-Based Rendering (PBR), by adding additional PBR material parameters, which reference per vertex attributes. These additional material parameters, allow for a full per vertex PBR workflow representation.
 
-Such material <-> mesh attribute referencing allows DCC applications to save multiple materials for a single mesh into a glTF file, which allows real-time engines to switch / blend between them at run-time. It also allows DCC applications to use glTF as a storage format, used for saving and loading artist defined shading configurations, while minimizing data loss and/or shading configuration change / conversion over the save and load cycle(s).
+Propsed material property to mesh attribute referencing allows DCC applications to save multiple materials for a single mesh into a glTF file, which then allows real-time engines to switch / blend between them at run-time. It also allows DCC applications to use glTF as a storage format, used for saving and loading artist defined shading configurations, while minimizing data loss and/or shading configuration change / conversion over multiple save and load cycle(s).
 
 ### Example
 ![\[Comparison\]](Figures/vertex_metal_rough_comparison.png)
@@ -66,7 +66,7 @@ Left: per-vertex albedo only. Right: per-vertex albedo attributes extended with 
         {
             "name": "game_asset_worn_out",
             "pbrMetallicRoughness": {
-                "baseColorFactor": [1, 1, 1, 1],
+                "baseColorFactor": [0.8, 0.8, 0.8, 1],
                 "metallicFactor" : 1,
                 "roughnessFactor": 0.8
             },
@@ -78,7 +78,7 @@ Left: per-vertex albedo only. Right: per-vertex albedo attributes extended with 
                     "metallicAttrib" : "METALLIC",
                 }
             }
-        }		
+        }       
     ],
     "meshes": [
         {
@@ -88,9 +88,9 @@ Left: per-vertex albedo only. Right: per-vertex albedo attributes extended with 
                     "material": 0,
                     "mode": 4,
                     "attributes": {
-						"_BASECOLOR_WORN_OUT": 7,
-					    "_ROUGHNESS_WORN_OUT": 6,
-						"METALLIC": 5,
+                        "_BASECOLOR_WORN_OUT": 7,
+                        "_ROUGHNESS_WORN_OUT": 6,
+                        "METALLIC": 5,
                         "_ROUGHNESS_BRAND_NEW": 4,
                         "_BASECOLOR_BRAND_NEW": 3,
                         "NORMAL": 2,
@@ -127,7 +127,7 @@ Valid accessor type and component type for each attribute semantic property are 
 |`METALLIC`|`"SCALAR"`|`5126`&nbsp;(FLOAT)<br>`5121`&nbsp;(UNSIGNED_BYTE)&nbsp;normalized<br>`5123`&nbsp;(UNSIGNED_SHORT)&nbsp;normalized|PBR Metallic Material Parameter|
 |`ROUGHNESS`|`"SCALAR"`|`5126`&nbsp;(FLOAT)<br>`5121`&nbsp;(UNSIGNED_BYTE)&nbsp;normalized<br>`5123`&nbsp;(UNSIGNED_SHORT)&nbsp;normalized|PBR Roughness Material Parameter|
  
-This extension allows user defined attributes (prefixed with "_") to be used instead of the default ones, with the same type limitations as specified in the above table.
+This extension allows user defined attributes (prefixed with "_") to be used instead of the default ones. User defined attributes need to adhere to the  same type limitations as specified in the above table.
 
 ## Best Practices
 
@@ -144,12 +144,12 @@ If sRGB was used for COLOR_0, the resulting color space and interpolation will b
 
 Implementations concerned with these potentially undesirable results, maybe choose to add the extension to `"extensionsRequired"`.
 
-To provide for a clean separation between meshes and materials, the following two considerations apply:
+For materials which have this extension, to be able to provide for clean separation between meshes and materials, the following two considerations apply:
 
 When COLOR_0 attribute exists in the mesh, and baseColorAttrib is defined, baseColorAttrib has the priority, and automatic usage of COLOR_0 attribute (as per Core specification) is ignored. 
 
 When COLOR_0 attribute exists in the mesh, and baseColorAttrib is not defined, 
-COLOR_0 is again ignored (not automatically applied).
+COLOR_0 is again ignored (not automatically applied as per Core specification).
 
 ## Known Implementations
 


### PR DESCRIPTION
This pull request adds the material -> attribute indirection, which improves artist workflow in DCC apps, and prevents data loss and unneeded / unexpected conversions when saving / loading .glTF files.

It allows artists to define and real-time engines to blend / switch between multiple materials, while at the same time keeping the data representation compact and optimal.

Please review it (@fhoenig, @abductee, @mmalex, @bghgary, @warrenm, @Nosferalatu, @donrmccurdy) , and if everyone agrees, I can polish it up and submit the final version.

Thanks,
Milan,
Game / VR / AR workflows lead dev.,
Modo Team, Foundry